### PR TITLE
feat: add SharePoint improvement suggestion web part

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+node_modules/
+lib/
+temp/
+sharepoint/solution/*.sppkg
+*.log
+.yo-rc.json
+config/deploy-*.json
+yarn.lock
+
+# Generated config
+*.package
+.sass-cache
+coverage/
+.snyk
+.env
+.vscode/
+.DS_Store
+

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/README.md
+++ b/README.md
@@ -1,1 +1,59 @@
-# Samverkansportalen
+# Förbättringsportalen för SharePoint Online
+
+Detta projekt innehåller en SharePoint Framework-webbdel som låter medarbetare föreslå förbättringar och rösta fram vilka förslag som ska prioriteras. Varje användare får fem samtidiga röster som automatiskt återförs när ett förslag markeras som genomfört eller borttaget. Borttagna förslag behålls i historiken och kan sökas fram på samma sätt som aktiva förslag.
+
+## Funktioner
+
+- Lägg till nya förbättringsförslag direkt från webbdelens gränssnitt.
+- Se hur många aktiva röster ett förslag har samt hur många röster du själv har kvar.
+- Rösta på eller återta din röst från aktiva förslag (status "Föreslagen" eller "Pågående").
+- Uppdatera status på förslag till "Genomförd" eller "Avslutad" (borttagen) utan att förlust av historik.
+- Sök bland samtliga förslag, inklusive avslutade eller borttagna.
+- Listor i SharePoint för förslag och röster provisioneras automatiskt vid första körning.
+
+## Teknisk översikt
+
+- **Plattform:** SharePoint Framework (SPFx) 1.17.4 med React.
+- **SharePoint-listor:**
+  - `ImprovementSuggestions` för själva förslagen.
+  - `SuggestionVotes` för röster kopplade till varje förslag.
+- **Bibliotek:** PnPjs används för att kommunicera med SharePoint och hantera listor och data.
+
+## Kom igång
+
+1. **Förberedelser**
+   - Installera Node.js 16 (>=16.13.0 och <17).
+   - Klona detta repo och öppna projektmappen.
+   - Kör `npm install` (projektet levereras med `.npmrc` som aktiverar `legacy-peer-deps`).
+
+2. **Utvecklingsläge**
+   - Kör `gulp serve` för att öppna lokal Workbench eller använd SharePoint Workbench (`/_layouts/workbench.aspx`).
+
+3. **Bygg och paketera för produktion**
+   ```bash
+   gulp bundle --ship
+   gulp package-solution --ship
+   ```
+   - Ladda upp den genererade `.sppkg`-filen under `sharepoint/solution/` till er appkatalog.
+   - Distribuera webbdelens app till den SharePoint-webbplats där den ska användas.
+
+4. **Lägg till på en sida**
+   - Redigera valfri modern sida i SharePoint.
+   - Lägg till webbdelens "Förbättringsportalen" och spara sidan.
+
+## Användning
+
+1. **Skapa förslag** – Fyll i titel och beskrivning och klicka på *Spara förslag*.
+2. **Rösta** – Klicka på *Rösta* på ett aktivt förslag för att använda en av dina fem röster.
+3. **Återta röst** – Klicka på *Återta röst* för att frigöra rösten innan förslaget är klart.
+4. **Ändra status** – Använd statuslistan på kortet för att markera förslag som pågående, genomfört eller avslutat. När status är "Genomförd" eller "Avslutad" återlämnas röster automatiskt och förslaget finns kvar i sökningen.
+
+## Vidareutveckling
+
+- Lägg till egna vyer eller kolumner i listorna om ytterligare metadata behövs.
+- Komplettera med notifieringar, exempelvis via Power Automate, när nya förslag skapas eller status ändras.
+- Anpassa UI:t i `ImprovementPortal.module.scss` för att matcha organisationens grafiska profil.
+
+## Support
+
+Om något inte fungerar, se till att kontot som kör webbdelens kod har rättigheter att skapa och uppdatera listor på webbplatsen. Kontrollera också att appen har distribuerats korrekt via appkatalogen.

--- a/config/config.json
+++ b/config/config.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/spfx-build/config.2.0.schema.json",
+  "version": "2.0",
+  "bundles": {
+    "improvement-portal-web-part": {
+      "components": [
+        {
+          "entrypoint": "./lib/webparts/improvementPortal/ImprovementPortalWebPart.js",
+          "manifest": "./src/webparts/improvementPortal/ImprovementPortalWebPart.manifest.json"
+        }
+      ]
+    }
+  },
+  "externals": {},
+  "localizedResources": {
+    "ImprovementPortalWebPartStrings": "lib/webparts/improvementPortal/loc/{locale}.js"
+  }
+}

--- a/config/package-solution.json
+++ b/config/package-solution.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/spfx/client-side-package-solution.schema.json",
+  "solution": {
+    "name": "samverkansportalen-improvements-client-side-solution",
+    "id": "478c64a0-e370-41fb-bcd7-aed42b3f7230",
+    "version": "1.0.0.0",
+    "includeClientSideAssets": true,
+    "skipFeatureDeployment": true,
+    "isDomainIsolated": false
+  },
+  "paths": {
+    "zippedPackage": "solution/samverkansportalen-improvements.sppkg"
+  }
+}

--- a/config/serve.json
+++ b/config/serve.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/spfx-build/serve.schema.json",
+  "port": 4321,
+  "https": true,
+  "initialPage": "https://contoso.sharepoint.com/sites/dev/_layouts/workbench.aspx"
+}

--- a/config/write-manifests.json
+++ b/config/write-manifests.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/spfx-build/write-manifests.schema.json",
+  "cdnBasePath": "https://publiccdn.sharepointonline.com/contoso.sharepoint.com/sites/apps/CDN"
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const gulp = require('gulp');
+const build = require('@microsoft/sp-build-web');
+
+build.addSuppression(`Warning - [sass] The local CSS class 'ms-Grid' is not camelCase and will not be type-safe.`);
+
+build.initialize(gulp);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "samverkansportalen-improvements",
+  "version": "0.1.0",
+  "private": true,
+  "main": "lib/index.js",
+  "engines": {
+    "node": ">=16.13.0 <17.0.0"
+  },
+  "scripts": {
+    "build": "gulp bundle",
+    "bundle": "gulp bundle",
+    "clean": "gulp clean",
+    "package": "gulp package-solution",
+    "serve": "gulp serve",
+    "test": "gulp test"
+  },
+  "dependencies": {
+    "@microsoft/sp-core-library": "1.17.4",
+    "@microsoft/sp-lodash-subset": "1.17.4",
+    "@microsoft/sp-office-ui-fabric-core": "1.17.4",
+    "@microsoft/sp-property-pane": "1.17.4",
+    "@microsoft/sp-webpart-base": "1.17.4",
+    "@pnp/sp": "2.15.0",
+    "@pnp/core": "2.15.0",
+    "office-ui-fabric-react": "7.185.0",
+    "react": "17.0.2",
+    "react-dom": "17.0.2",
+    "@pnp/spfx": "2.15.0"
+  },
+  "devDependencies": {
+    "@microsoft/sp-build-web": "1.17.4",
+    "@microsoft/sp-module-interfaces": "1.17.4",
+    "@microsoft/sp-tslint-rules": "1.17.4",
+    "@microsoft/sp-webpart-workbench": "1.17.4",
+    "@microsoft/rush-stack-compiler-4.5": "0.5.1",
+    "@types/react": "17.0.52",
+    "@types/react-dom": "17.0.19",
+    "gulp": "~4.0.2",
+    "tslint": "~6.1.3",
+    "typescript": "4.5.5"
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,1 @@
+export * from './webparts/improvementPortal/ImprovementPortalWebPart';

--- a/src/webparts/improvementPortal/ImprovementPortalWebPart.manifest.json
+++ b/src/webparts/improvementPortal/ImprovementPortalWebPart.manifest.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/spfx/client-side-web-part-manifest.schema.json",
+  "id": "ca0e63aa-5924-409f-be87-dfa7cf752925",
+  "alias": "ImprovementPortalWebPart",
+  "componentType": "WebPart",
+  "version": "1.0.0",
+  "manifestVersion": 2,
+  "requiresCustomScript": false,
+  "supportedHosts": [
+    "SharePointWebPart",
+    "TeamsPersonalApp",
+    "TeamsTab",
+    "TeamsMeetingStage",
+    "OfficeTab"
+  ],
+  "preconfiguredEntries": [
+    {
+      "title": {
+        "default": "Förbättringsportalen"
+      },
+      "description": {
+        "default": "Hantera förbättringsförslag och röster i SharePoint."
+      },
+      "officeFabricIconFontName": "LightningBolt",
+      "properties": {
+        "description": "Förbättringsportalen"
+      }
+    }
+  ]
+}

--- a/src/webparts/improvementPortal/ImprovementPortalWebPart.ts
+++ b/src/webparts/improvementPortal/ImprovementPortalWebPart.ts
@@ -1,0 +1,69 @@
+import * as React from 'react';
+import * as ReactDom from 'react-dom';
+import { Version } from '@microsoft/sp-core-library';
+import {
+  IPropertyPaneConfiguration,
+  PropertyPaneTextField
+} from '@microsoft/sp-property-pane';
+import { BaseClientSideWebPart } from '@microsoft/sp-webpart-base';
+
+import * as strings from 'ImprovementPortalWebPartStrings';
+import ImprovementPortal, { IImprovementPortalProps } from './components/ImprovementPortal';
+import { spfi, SPFI } from '@pnp/sp';
+import { SPFx } from '@pnp/spfx';
+
+export interface IImprovementPortalWebPartProps {
+  description: string;
+}
+
+export default class ImprovementPortalWebPart extends BaseClientSideWebPart<IImprovementPortalWebPartProps> {
+
+  private _sp: SPFI;
+
+  protected async onInit(): Promise<void> {
+    await super.onInit();
+    this._sp = spfi().using(SPFx(this.context));
+  }
+
+  public render(): void {
+    const element: React.ReactElement<IImprovementPortalProps> = React.createElement(
+      ImprovementPortal,
+      {
+        description: this.properties.description,
+        sp: this._sp
+      }
+    );
+
+    ReactDom.render(element, this.domElement);
+  }
+
+  protected onDispose(): void {
+    ReactDom.unmountComponentAtNode(this.domElement);
+  }
+
+  protected get dataVersion(): Version {
+    return Version.parse('1.0');
+  }
+
+  protected getPropertyPaneConfiguration(): IPropertyPaneConfiguration {
+    return {
+      pages: [
+        {
+          header: {
+            description: strings.PropertyPaneDescription
+          },
+          groups: [
+            {
+              groupName: strings.BasicGroupName,
+              groupFields: [
+                PropertyPaneTextField('description', {
+                  label: strings.DescriptionFieldLabel
+                })
+              ]
+            }
+          ]
+        }
+      ]
+    };
+  }
+}

--- a/src/webparts/improvementPortal/components/ImprovementPortal.module.scss
+++ b/src/webparts/improvementPortal/components/ImprovementPortal.module.scss
@@ -1,0 +1,108 @@
+.portal {
+  padding: 20px;
+}
+
+.header {
+  margin-bottom: 16px;
+}
+
+.controls {
+  margin-bottom: 16px;
+}
+
+.voteSummary {
+  margin-bottom: 20px;
+}
+
+.form {
+  background-color: #faf9f8;
+  border: 1px solid #edebe9;
+  border-radius: 4px;
+  padding: 16px;
+  margin-bottom: 24px;
+}
+
+.formButtons {
+  margin-top: 12px;
+  display: flex;
+  gap: 8px;
+}
+
+.searchRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: flex-end;
+  margin-bottom: 16px;
+}
+
+.sectionTitle {
+  margin: 24px 0 8px;
+  font-weight: 600;
+}
+
+.suggestionCard {
+  background: #fff;
+  border: 1px solid #edebe9;
+  border-radius: 6px;
+  padding: 16px;
+  margin-bottom: 12px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+
+.cardHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.statusBadge {
+  background: #f3f2f1;
+  color: #323130;
+  padding: 4px 10px;
+  border-radius: 20px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.meta {
+  color: #605e5c;
+  font-size: 12px;
+  margin-top: 4px;
+  margin-bottom: 12px;
+}
+
+.description {
+  white-space: pre-line;
+  margin-bottom: 16px;
+}
+
+.voteActions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.voteCounter {
+  font-weight: 600;
+}
+
+.statusControls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 16px;
+}
+
+.emptyState {
+  padding: 32px 16px;
+  text-align: center;
+  color: #8a8886;
+}
+
+.messageBar {
+  margin-bottom: 12px;
+}

--- a/src/webparts/improvementPortal/components/ImprovementPortal.module.scss.ts
+++ b/src/webparts/improvementPortal/components/ImprovementPortal.module.scss.ts
@@ -1,0 +1,24 @@
+require('./ImprovementPortal.module.css');
+
+const styles = {
+  portal: 'portal',
+  header: 'header',
+  controls: 'controls',
+  voteSummary: 'voteSummary',
+  form: 'form',
+  formButtons: 'formButtons',
+  searchRow: 'searchRow',
+  sectionTitle: 'sectionTitle',
+  suggestionCard: 'suggestionCard',
+  cardHeader: 'cardHeader',
+  statusBadge: 'statusBadge',
+  meta: 'meta',
+  description: 'description',
+  voteActions: 'voteActions',
+  voteCounter: 'voteCounter',
+  statusControls: 'statusControls',
+  emptyState: 'emptyState',
+  messageBar: 'messageBar'
+};
+
+export default styles;

--- a/src/webparts/improvementPortal/components/ImprovementPortal.tsx
+++ b/src/webparts/improvementPortal/components/ImprovementPortal.tsx
@@ -1,0 +1,382 @@
+import * as React from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { SPFI } from '@pnp/sp';
+import {
+  DefaultButton,
+  Dropdown,
+  IDropdownOption,
+  MessageBar,
+  MessageBarType,
+  PrimaryButton,
+  SearchBox,
+  Spinner,
+  SpinnerSize,
+  Stack,
+  Text,
+  TextField
+} from 'office-ui-fabric-react';
+import SuggestionService from '../services/SuggestionService';
+import {
+  ISuggestionWithVotes,
+  SuggestionStatus,
+  activeStatuses,
+  suggestionStatusOptions
+} from '../models/ImprovementModels';
+import styles from './ImprovementPortal.module.scss';
+
+const MAX_VOTES = 5;
+
+export interface IImprovementPortalProps {
+  description: string;
+  sp: SPFI;
+}
+
+type FeedbackMessage = {
+  text: string;
+  type: MessageBarType;
+};
+
+const statusDropdownOptions: IDropdownOption[] = suggestionStatusOptions.map((option) => ({
+  key: option.key,
+  text: option.text
+}));
+
+const ImprovementPortal: React.FunctionComponent<IImprovementPortalProps> = (props: IImprovementPortalProps) => {
+  const serviceRef = useRef<SuggestionService>();
+  if (!serviceRef.current) {
+    serviceRef.current = new SuggestionService(props.sp);
+  }
+  const service = serviceRef.current;
+
+  const [suggestions, setSuggestions] = useState<ISuggestionWithVotes[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [working, setWorking] = useState<boolean>(false);
+  const [error, setError] = useState<string | undefined>();
+  const [feedback, setFeedback] = useState<FeedbackMessage | undefined>();
+  const [searchValue, setSearchValue] = useState<string>('');
+  const [currentUserId, setCurrentUserId] = useState<number | undefined>();
+  const [newTitle, setNewTitle] = useState<string>('');
+  const [newDescription, setNewDescription] = useState<string>('');
+  const [titleError, setTitleError] = useState<string | undefined>();
+
+  const statusLabelMap = useMemo(() => {
+    const map = new Map<SuggestionStatus, string>();
+    suggestionStatusOptions.forEach((option) => map.set(option.key, option.text));
+    return map;
+  }, []);
+
+  const loadInitialData = useCallback(async () => {
+    setLoading(true);
+    setError(undefined);
+    try {
+      await service.ensureSetup();
+      const user = await service.getCurrentUser();
+      setCurrentUserId(user.id);
+      const loadedSuggestions = await service.getSuggestions('', user.id);
+      setSuggestions(loadedSuggestions);
+      setSearchValue('');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Det gick inte att läsa in data.';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }, [service]);
+
+  useEffect(() => {
+    loadInitialData();
+  }, [loadInitialData]);
+
+  const refreshSuggestions = useCallback(
+    async (query?: string) => {
+      if (currentUserId === undefined) {
+        return;
+      }
+      setLoading(true);
+      setError(undefined);
+      try {
+        const items = await service.getSuggestions(query !== undefined ? query : searchValue, currentUserId);
+        setSuggestions(items);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Kunde inte uppdatera listan med förslag.';
+        setError(message);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [service, currentUserId, searchValue]
+  );
+
+  const availableVotes = useMemo(() => {
+    const activeVotes = suggestions.filter((item) => item.userHasActiveVote).length;
+    const remaining = MAX_VOTES - activeVotes;
+    return remaining > 0 ? remaining : 0;
+  }, [suggestions]);
+
+  const handleSearch = useCallback(
+    async (value?: string) => {
+      const query = value ? value.trim() : '';
+      setSearchValue(query);
+      await refreshSuggestions(query);
+    },
+    [refreshSuggestions]
+  );
+
+  const handleVote = useCallback(
+    async (suggestion: ISuggestionWithVotes) => {
+      if (currentUserId === undefined) {
+        return;
+      }
+      if (availableVotes <= 0) {
+        setFeedback({ text: 'Du har inga röster kvar att använda just nu.', type: MessageBarType.warning });
+        return;
+      }
+      try {
+        setWorking(true);
+        await service.addVote(suggestion.id, currentUserId);
+        await refreshSuggestions();
+        setFeedback({ text: `Du har röstat på "${suggestion.title}".`, type: MessageBarType.success });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Kunde inte registrera din röst.';
+        setFeedback({ text: message, type: MessageBarType.error });
+      } finally {
+        setWorking(false);
+      }
+    },
+    [service, currentUserId, availableVotes, refreshSuggestions]
+  );
+
+  const handleWithdrawVote = useCallback(
+    async (suggestion: ISuggestionWithVotes) => {
+      if (!suggestion.userVoteId) {
+        return;
+      }
+      try {
+        setWorking(true);
+        await service.withdrawVote(suggestion.userVoteId);
+        await refreshSuggestions();
+        setFeedback({ text: 'Din röst har tagits bort från förslaget.', type: MessageBarType.success });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Kunde inte ta bort din röst.';
+        setFeedback({ text: message, type: MessageBarType.error });
+      } finally {
+        setWorking(false);
+      }
+    },
+    [service, refreshSuggestions]
+  );
+
+  const handleStatusChange = useCallback(
+    async (suggestion: ISuggestionWithVotes, status: SuggestionStatus) => {
+      if (suggestion.status === status) {
+        return;
+      }
+      try {
+        setWorking(true);
+        await service.updateSuggestionStatus(suggestion.id, status);
+        await refreshSuggestions();
+        const statusLabel = statusLabelMap.get(status) || status;
+        setFeedback({ text: `Förslaget markerades som ${statusLabel}.`, type: MessageBarType.success });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Kunde inte uppdatera status för förslaget.';
+        setFeedback({ text: message, type: MessageBarType.error });
+      } finally {
+        setWorking(false);
+      }
+    },
+    [service, refreshSuggestions, statusLabelMap]
+  );
+
+  const handleCreateSuggestion = useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      setFeedback(undefined);
+      if (!newTitle || newTitle.trim().length === 0) {
+        setTitleError('Ange en titel för förslaget.');
+        return;
+      }
+      try {
+        setWorking(true);
+        await service.createSuggestion(newTitle.trim(), newDescription.trim());
+        setNewTitle('');
+        setNewDescription('');
+        setTitleError(undefined);
+        await refreshSuggestions();
+        setFeedback({ text: 'Förslaget har lagts till.', type: MessageBarType.success });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Kunde inte spara förslaget.';
+        setFeedback({ text: message, type: MessageBarType.error });
+      } finally {
+        setWorking(false);
+      }
+    },
+    [service, newTitle, newDescription, refreshSuggestions]
+  );
+
+  const resetForm = useCallback(() => {
+    setNewTitle('');
+    setNewDescription('');
+    setTitleError(undefined);
+  }, []);
+
+  const activeSuggestions = useMemo(
+    () =>
+      suggestions
+        .filter((item) => activeStatuses.includes(item.status))
+        .sort((a, b) => {
+          if (b.activeVotes !== a.activeVotes) {
+            return b.activeVotes - a.activeVotes;
+          }
+          return new Date(b.created).getTime() - new Date(a.created).getTime();
+        }),
+    [suggestions]
+  );
+
+  const archivedSuggestions = useMemo(
+    () =>
+      suggestions
+        .filter((item) => !activeStatuses.includes(item.status))
+        .sort((a, b) => new Date(b.created).getTime() - new Date(a.created).getTime()),
+    [suggestions]
+  );
+
+  const renderSuggestion = (suggestion: ISuggestionWithVotes) => {
+    const createdDate = suggestion.created ? new Date(suggestion.created).toLocaleDateString() : '';
+    const isActive = activeStatuses.includes(suggestion.status);
+    const statusLabel = statusLabelMap.get(suggestion.status) || suggestion.status;
+
+    return (
+      <div key={suggestion.id} className={styles.suggestionCard}>
+        <div className={styles.cardHeader}>
+          <Text variant="large">{suggestion.title}</Text>
+          <span className={styles.statusBadge}>{statusLabel}</span>
+        </div>
+        <div className={styles.meta}>
+          {suggestion.createdBy?.title && (
+            <span>
+              Skapad av {suggestion.createdBy.title} den {createdDate}
+            </span>
+          )}
+        </div>
+        {suggestion.description && <div className={styles.description}>{suggestion.description}</div>}
+        <div className={styles.voteActions}>
+          <span className={styles.voteCounter}>
+            {isActive ? `Aktiva röster: ${suggestion.activeVotes}` : `Historiska röster: ${suggestion.totalVotes}`}
+          </span>
+          {isActive && suggestion.userHasActiveVote && <span>Du har röstat på detta förslag.</span>}
+          {isActive && !suggestion.userHasActiveVote && availableVotes <= 0 && (
+            <span>Du har inga röster kvar att använda.</span>
+          )}
+          {isActive && suggestion.userHasActiveVote ? (
+            <DefaultButton
+              text="Återta röst"
+              onClick={() => handleWithdrawVote(suggestion)}
+              disabled={working}
+            />
+          ) : null}
+          {isActive && !suggestion.userHasActiveVote ? (
+            <PrimaryButton text="Rösta" onClick={() => handleVote(suggestion)} disabled={working || availableVotes <= 0} />
+          ) : null}
+          {!isActive && suggestion.userHasAnyVote && (
+            <span>Din röst har återlämnats.</span>
+          )}
+        </div>
+        <div className={styles.statusControls}>
+          <span>Status:</span>
+          <Dropdown
+            options={statusDropdownOptions}
+            selectedKey={suggestion.status}
+            onChange={(_, option) => option && handleStatusChange(suggestion, option.key as SuggestionStatus)}
+            disabled={working}
+          />
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div className={styles.portal}>
+      <div className={styles.header}>
+        <Text variant="xLarge">Förbättringsportalen</Text>
+        {props.description && <Text>{props.description}</Text>}
+      </div>
+
+      {feedback && (
+        <MessageBar
+          className={styles.messageBar}
+          messageBarType={feedback.type}
+          isMultiline={false}
+          onDismiss={() => setFeedback(undefined)}
+          dismissButtonAriaLabel="Stäng"
+        >
+          {feedback.text}
+        </MessageBar>
+      )}
+
+      {error && (
+        <MessageBar
+          className={styles.messageBar}
+          messageBarType={MessageBarType.error}
+          isMultiline={false}
+          onDismiss={() => setError(undefined)}
+        >
+          {error}
+        </MessageBar>
+      )}
+
+      <form className={styles.form} onSubmit={handleCreateSuggestion}>
+        <Text variant="large">Lägg till nytt förslag</Text>
+        <TextField
+          label="Titel"
+          value={newTitle}
+          onChange={(_, value) => {
+            setNewTitle(value || '');
+            setTitleError(undefined);
+          }}
+          required
+          errorMessage={titleError}
+        />
+        <TextField
+          label="Beskrivning"
+          multiline
+          rows={4}
+          value={newDescription}
+          onChange={(_, value) => setNewDescription(value || '')}
+        />
+        <div className={styles.formButtons}>
+          <PrimaryButton type="submit" text="Spara förslag" disabled={working} />
+          <DefaultButton text="Rensa" onClick={resetForm} disabled={working} />
+        </div>
+      </form>
+
+      <div className={styles.controls}>
+        <div className={styles.searchRow}>
+          <SearchBox
+            placeholder="Sök efter titel eller beskrivning"
+            value={searchValue}
+            onSearch={handleSearch}
+            onChange={(_, value) => setSearchValue(value || '')}
+            onClear={() => handleSearch('')}
+          />
+          <Text variant="mediumPlus">Tillgängliga röster: {availableVotes} av {MAX_VOTES}</Text>
+        </div>
+      </div>
+
+      {loading ? (
+        <Spinner size={SpinnerSize.large} label="Laddar förslag..." />
+      ) : suggestions.length === 0 ? (
+        <div className={styles.emptyState}>Inga förslag hittades. Lägg till ett nytt eller ändra sökningen.</div>
+      ) : (
+        <Stack tokens={{ childrenGap: 12 }}>
+          {activeSuggestions.length > 0 && <Text className={styles.sectionTitle}>Aktiva förbättringsförslag</Text>}
+          {activeSuggestions.map((suggestion) => renderSuggestion(suggestion))}
+
+          {archivedSuggestions.length > 0 && <Text className={styles.sectionTitle}>Avslutade eller borttagna förslag</Text>}
+          {archivedSuggestions.map((suggestion) => renderSuggestion(suggestion))}
+        </Stack>
+      )}
+    </div>
+  );
+};
+
+export default ImprovementPortal;

--- a/src/webparts/improvementPortal/loc/en-us.js
+++ b/src/webparts/improvementPortal/loc/en-us.js
@@ -1,0 +1,7 @@
+define([], function() {
+  return {
+    "PropertyPaneDescription": "Configure the improvement portal web part.",
+    "BasicGroupName": "General",
+    "DescriptionFieldLabel": "Description"
+  };
+});

--- a/src/webparts/improvementPortal/loc/mystrings.d.ts
+++ b/src/webparts/improvementPortal/loc/mystrings.d.ts
@@ -1,0 +1,10 @@
+declare interface IImprovementPortalWebPartStrings {
+  PropertyPaneDescription: string;
+  BasicGroupName: string;
+  DescriptionFieldLabel: string;
+}
+
+declare module 'ImprovementPortalWebPartStrings' {
+  const strings: IImprovementPortalWebPartStrings;
+  export = strings;
+}

--- a/src/webparts/improvementPortal/loc/sv-se.js
+++ b/src/webparts/improvementPortal/loc/sv-se.js
@@ -1,0 +1,7 @@
+define([], function() {
+  return {
+    "PropertyPaneDescription": "Anpassa förbättringsportalen.",
+    "BasicGroupName": "Allmänt",
+    "DescriptionFieldLabel": "Beskrivning"
+  };
+});

--- a/src/webparts/improvementPortal/models/ImprovementModels.ts
+++ b/src/webparts/improvementPortal/models/ImprovementModels.ts
@@ -1,0 +1,33 @@
+export type SuggestionStatus = 'Proposed' | 'InProgress' | 'Completed' | 'Removed';
+
+export const activeStatuses: SuggestionStatus[] = ['Proposed', 'InProgress'];
+
+export const suggestionStatusOptions: { key: SuggestionStatus; text: string }[] = [
+  { key: 'Proposed', text: 'Föreslagen' },
+  { key: 'InProgress', text: 'Pågående' },
+  { key: 'Completed', text: 'Genomförd' },
+  { key: 'Removed', text: 'Avslutad' }
+];
+
+export interface IUserInfo {
+  id?: number;
+  title: string;
+  email?: string;
+}
+
+export interface ISuggestionItem {
+  id: number;
+  title: string;
+  description: string;
+  status: SuggestionStatus;
+  created: string;
+  createdBy: IUserInfo;
+}
+
+export interface ISuggestionWithVotes extends ISuggestionItem {
+  totalVotes: number;
+  activeVotes: number;
+  userHasActiveVote: boolean;
+  userVoteId?: number;
+  userHasAnyVote: boolean;
+}

--- a/src/webparts/improvementPortal/services/SuggestionService.ts
+++ b/src/webparts/improvementPortal/services/SuggestionService.ts
@@ -1,0 +1,189 @@
+import { SPFI } from '@pnp/sp';
+import '@pnp/sp/items';
+import '@pnp/sp/lists';
+import '@pnp/sp/webs';
+import '@pnp/sp/site-users/web';
+import '@pnp/sp/fields';
+import '@pnp/sp/views';
+import { ISuggestionWithVotes, SuggestionStatus, IUserInfo, activeStatuses } from '../models/ImprovementModels';
+
+const SUGGESTION_LIST_TITLE = 'ImprovementSuggestions';
+const VOTE_LIST_TITLE = 'SuggestionVotes';
+
+export default class SuggestionService {
+  private readonly _maxSuggestions = 500;
+
+  public constructor(private readonly sp: SPFI) {}
+
+  public async ensureSetup(): Promise<void> {
+    const suggestionListId = await this.ensureSuggestionList();
+    await this.ensureVotesList(suggestionListId);
+  }
+
+  public async getCurrentUser(): Promise<IUserInfo> {
+    const user = await this.sp.web.currentUser.select('Id', 'Title', 'Email')();
+    return {
+      id: user.Id,
+      title: user.Title,
+      email: user.Email
+    };
+  }
+
+  public async getSuggestions(searchText: string | undefined, currentUserId: number): Promise<ISuggestionWithVotes[]> {
+    const suggestionList = this.sp.web.lists.getByTitle(SUGGESTION_LIST_TITLE);
+
+    let request = suggestionList.items
+      .select('Id', 'Title', 'SuggestionDescription', 'SuggestionStatus', 'Created', 'Author/Id', 'Author/Title', 'Author/EMail')
+      .expand('Author')
+      .orderBy('Created', false)
+      .top(this._maxSuggestions);
+
+    if (searchText && searchText.trim().length > 0) {
+      const escaped = this.escapeForOData(searchText.trim());
+      request = request.filter(`substringof('${escaped}',Title) or substringof('${escaped}',SuggestionDescription)`);
+    }
+
+    const suggestionItems = await request();
+
+    if (!suggestionItems || suggestionItems.length === 0) {
+      return [];
+    }
+
+    const suggestionIds = suggestionItems.map((item) => item.Id);
+    const filters = suggestionIds.map((id) => `(SuggestionId eq ${id})`).join(' or ');
+    const voteFilter = filters.length > 0 ? `IsWithdrawn eq 0 and (${filters})` : 'IsWithdrawn eq 0';
+
+    const voteItems = await this.sp.web.lists
+      .getByTitle(VOTE_LIST_TITLE)
+      .items.select('Id', 'SuggestionId', 'Voter/Id', 'Voter/Title')
+      .expand('Voter')
+      .filter(voteFilter)
+      .top(5000)();
+
+    const votesBySuggestion = new Map<number, { id: number; voterId: number; voterName: string }[]>();
+    for (const vote of voteItems) {
+      const suggestionId: number = vote.SuggestionId;
+      let entries = votesBySuggestion.get(suggestionId);
+      if (!entries) {
+        entries = [];
+        votesBySuggestion.set(suggestionId, entries);
+      }
+      entries.push({
+        id: vote.Id,
+        voterId: vote.Voter ? vote.Voter.Id : undefined,
+        voterName: vote.Voter ? vote.Voter.Title : ''
+      });
+    }
+
+    return suggestionItems.map((item) => {
+      const status = (item.SuggestionStatus || 'Proposed') as SuggestionStatus;
+      const votes = votesBySuggestion.get(item.Id) || [];
+      const userVote = votes.find((vote) => vote.voterId === currentUserId);
+      const isActive = activeStatuses.indexOf(status) >= 0;
+
+      return {
+        id: item.Id,
+        title: item.Title,
+        description: item.SuggestionDescription || '',
+        status,
+        created: item.Created,
+        createdBy: {
+          id: item.Author ? item.Author.Id : undefined,
+          title: item.Author ? item.Author.Title : 'Okänd',
+          email: item.Author ? item.Author.EMail : undefined
+        },
+        totalVotes: votes.length,
+        activeVotes: isActive ? votes.length : 0,
+        userHasActiveVote: isActive && !!userVote,
+        userVoteId: userVote ? userVote.id : undefined,
+        userHasAnyVote: !!userVote
+      };
+    });
+  }
+
+  public async createSuggestion(title: string, description: string): Promise<void> {
+    await this.sp.web.lists.getByTitle(SUGGESTION_LIST_TITLE).items.add({
+      Title: title,
+      SuggestionDescription: description,
+      SuggestionStatus: 'Proposed'
+    });
+  }
+
+  public async updateSuggestionStatus(id: number, status: SuggestionStatus): Promise<void> {
+    await this.sp.web.lists.getByTitle(SUGGESTION_LIST_TITLE).items.getById(id).update({
+      SuggestionStatus: status
+    });
+  }
+
+  public async addVote(suggestionId: number, userId: number): Promise<void> {
+    const existing = await this.sp.web.lists
+      .getByTitle(VOTE_LIST_TITLE)
+      .items.select('Id')
+      .filter(`SuggestionId eq ${suggestionId} and VoterId eq ${userId} and IsWithdrawn eq 0`)
+      .top(1)();
+
+    if (existing.length > 0) {
+      return;
+    }
+
+    await this.sp.web.lists.getByTitle(VOTE_LIST_TITLE).items.add({
+      Title: `Vote-${suggestionId}-${userId}`,
+      SuggestionId: suggestionId,
+      VoterId: userId,
+      IsWithdrawn: false
+    });
+  }
+
+  public async withdrawVote(voteId: number): Promise<void> {
+    await this.sp.web.lists
+      .getByTitle(VOTE_LIST_TITLE)
+      .items.getById(voteId)
+      .update({ IsWithdrawn: true });
+  }
+
+  private async ensureSuggestionList(): Promise<string> {
+    const ensureResult = await this.sp.web.lists.ensure(SUGGESTION_LIST_TITLE, 'Förbättringsförslag', 100);
+    const suggestionList = ensureResult.list;
+
+    if (ensureResult.created) {
+      await suggestionList.fields.createFieldAsXml(
+        '<Field DisplayName="Beskrivning" Type="Note" Name="SuggestionDescription" NumLines="6" RichText="FALSE" />'
+      );
+      await suggestionList.fields.createFieldAsXml(
+        '<Field DisplayName="Status" Type="Choice" Name="SuggestionStatus" Format="Dropdown">' +
+          '<CHOICES>' +
+          '<CHOICE>Proposed</CHOICE>' +
+          '<CHOICE>InProgress</CHOICE>' +
+          '<CHOICE>Completed</CHOICE>' +
+          '<CHOICE>Removed</CHOICE>' +
+          '</CHOICES>' +
+          '<Default>Proposed</Default>' +
+          '</Field>'
+      );
+    }
+
+    const info = await suggestionList.select('Id')();
+    return info.Id;
+  }
+
+  private async ensureVotesList(suggestionListId: string): Promise<void> {
+    const ensureResult = await this.sp.web.lists.ensure(VOTE_LIST_TITLE, 'Röster på förbättringsförslag', 100);
+    const voteList = ensureResult.list;
+
+    if (ensureResult.created) {
+      await voteList.fields.createFieldAsXml(
+        `<Field DisplayName="Förslag" Type="Lookup" Required="TRUE" Name="Suggestion" List="{${suggestionListId}}" ShowField="Title" />`
+      );
+      await voteList.fields.createFieldAsXml(
+        '<Field DisplayName="Röstare" Type="User" Name="Voter" UserSelectionMode="PeopleOnly" UserSelectionScope="0" />'
+      );
+      await voteList.fields.createFieldAsXml(
+        '<Field DisplayName="Återtagen" Type="Boolean" Name="IsWithdrawn" Default="0" />'
+      );
+    }
+  }
+
+  private escapeForOData(value: string): string {
+    return value.replace(/'/g, "''");
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./node_modules/@microsoft/rush-stack-compiler-4.5/includes/tsconfig-web.json",
+  "compilerOptions": {
+    "target": "es5"
+  }
+}

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./node_modules/@microsoft/sp-tslint-rules/base-tslint.json",
+  "rules": {
+    "typedef": [
+      true,
+      "call-signature",
+      "property-declaration",
+      "member-variable-declaration"
+    ],
+    "no-unused-expression": true,
+    "no-use-before-declare": true,
+    "no-empty": false,
+    "typedef-whitespace": false,
+    "insecure-random": false
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold a SharePoint Framework React web part for managing improvement suggestions and voting
- add a PnP.js service that provisions SharePoint lists and enforces the five-vote-per-user rule with automatic vote returns
- build a user interface for submitting, searching, voting on, and updating the status of suggestions while keeping removed items searchable

## Testing
- not run (SharePoint Framework tooling requires Node 16 and the container currently provides Node 20)


------
https://chatgpt.com/codex/tasks/task_e_68d40b51f150832193257a2fb9a0943e